### PR TITLE
Add background shapes to Resources page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,40 @@ const useStyles = makeStyles( theme => ({
     }
   },
   resourcesPageBk: {
-    background: 'linear-gradient(#BD074C 10%, #4C2679, #210040)'
+    background: 'linear-gradient(#BD074C 10%, #4C2679, #210040)',
+  },
+  circle: {
+    position: 'absolute',
+    top: '115vw',
+    left: '-100px',
+    borderRadius: '50%',
+    width: '708px',
+    height: '708px',
+    background: 'rgba(255, 255, 255, 0.15)',
+    opacity: '0.5',
+    boxShadow: '0px 4px 10px 5px rgba(0, 0, 0, 0.25)'
+  },
+  square: {
+    position: 'absolute',
+    top: '150vw',
+    right: '-330px',
+    width: '503px',
+    height: '516px',
+    background: 'rgba(255, 255, 255, 0.15)',
+    boxShadow: '0px 4px 10px 5px rgba(0, 0, 0, 0.25)',
+    transform: 'rotate(31.35deg)'
+  },
+  hexagon: {
+    position: 'absolute',
+    top: '230vw',
+    left: '-500px',
+    width:' 840px',
+    height: '840px',
+    clipPath: 'polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0 50%)',
+    opacity: '0.15',
+    background: 'white',
+    boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.25)',
+    transform: 'rotate(139.2deg)'
   },
   positiveCultureofErrorCardContent:{
     marginTop: "20px",

--- a/src/components/molecules/PositiveCultureBox.jsx
+++ b/src/components/molecules/PositiveCultureBox.jsx
@@ -5,13 +5,13 @@ import quote from '../../images/Resources_Quote.png'
 function PositiveCultureBox(props) {
     const { styles } = props
         return(
-          <Card className={styles.cardIntro} style={{background: 'rgba(41, 0, 83, 0.8)', mixBlendMode: 'initial'}}>
+          <Card className={styles.cardIntro} style={{background: 'linear-gradient(52.63deg, #FF3369 0%, #662AAF 73.19%)', mixBlendMode: 'initial'}}> {/*background: 'rgba(41, 0, 83, 0.8)'*/}
               <CardContent>
               <Grid container justify="center" alignItems="center" spacing={3}>
                   <Grid item xs={6} md={5} lg={7} style={{padding: 'initial'}}>
                     <Typography variant="h4">Positive Culture of Error</Typography>
                     <Typography variant="h6" className={styles.positiveCultureofErrorCardContent}>
-                    In his book, Teach Like a Champion, veteran educator Doug Lemov talks about creating a classroom environment where “...students feel safe making and discussing mistakes, so you can spend less time hunting for errors and more time fixing them...” He outlines four key methods:
+                    In his book, <u><a href="https://www.google.com/">Teach Like a Champion</a></u>, veteran educator Doug Lemov talks about creating a classroom environment where “...students feel safe making and discussing mistakes, so you can spend less time hunting for errors and more time fixing them...” He outlines four key methods:
                       <ul>
                         <li>Expect error</li>
                         <li>Withhold answers</li>

--- a/src/components/organisms/CRMT.jsx
+++ b/src/components/organisms/CRMT.jsx
@@ -6,7 +6,7 @@ export default function CRMT(props) {
     // const { styles } = props;
     return(
         <Box component="section">
-            <Grid container style={ {justifyContent: "center"} }>
+            <Grid container style={ {justifyContent: "center", paddingTop: '10px'} }>
                 <Typography variant="h4" style={{color: 'white'}}>Culturally Responsive Mathematics Teaching</Typography>
             </Grid>
             <img src={CRMTimage} alt="CRMT-Diagram" style={ {display: 'flex', margin:'auto', width: "70%"} } />

--- a/src/components/organisms/ResourcePageShapes.jsx
+++ b/src/components/organisms/ResourcePageShapes.jsx
@@ -1,0 +1,43 @@
+const circle = {
+    position: 'absolute',
+    top: '65vw',
+    left: '-5vw',
+    borderRadius: '50%',
+    width: '708px',
+    height: '708px',
+    background: 'rgba(255, 255, 255, 0.15)',
+    opacity: '0.5',
+    boxShadow: '0px 4px 10px 5px rgba(0, 0, 0, 0.25)'
+}
+const square = {
+    position: 'absolute',
+    top: '130vw',
+    left: '85vw',
+    width: '503px',
+    height: '516px',
+    background: 'rgba(255, 255, 255, 0.15)',
+    boxShadow: '0px 4px 10px 5px rgba(0, 0, 0, 0.25)',
+    transform: 'rotate(31.35deg)'
+}
+const hexagon = {
+    position: 'absolute',
+    top: '200vw',
+    left: '-30vw',
+    width:' 840px',
+    height: '840px',
+    clipPath: 'polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0 50%)',
+    opacity: '0.15',
+    background: 'white',
+    boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.25)',
+    transform: 'rotate(139.2deg)'
+}
+
+export default function ResourcePageShapes() {
+    return(
+        <div style={ {position: 'absolute', zIndex: '0', width: '100%', height: '100%', overflow: 'hidden'} }>
+            <div style={circle} />
+            <div style={square} />
+            <div style={hexagon} />
+        </div>
+    )
+};

--- a/src/components/pages/ResourcePage.jsx
+++ b/src/components/pages/ResourcePage.jsx
@@ -9,9 +9,12 @@ function ResourcePage(props) {
         return(
             <div className={styles.resourcesPageBk}>
                 <PositiveCultureOfErrorSection styles={styles}/>
+                <div className={styles.circle} />
                 <CRMT />
+                <div className={styles.square} />
                 <ErrorAnalysisActivitiesSection styles={styles}/>
                 <RightOnGameShow />
+                <div className={styles.hexagon} />
             </div>
         )
     }

--- a/src/components/pages/ResourcePage.jsx
+++ b/src/components/pages/ResourcePage.jsx
@@ -3,18 +3,19 @@ import PositiveCultureOfErrorSection from '../organisms/PositiveCultureOfErrorSe
 import ErrorAnalysisActivitiesSection from '../organisms/ErrorAnalysisActivitiesSection';
 import CRMT from '../organisms/CRMT';
 import RightOnGameShow from '../organisms/RightOnGameShow';
+import ResourcePageShapes from '../organisms/ResourcePageShapes';
 
 function ResourcePage(props) {
     const { styles } = props
         return(
-            <div className={styles.resourcesPageBk}>
-                <PositiveCultureOfErrorSection styles={styles}/>
-                <div className={styles.circle} />
-                <CRMT />
-                <div className={styles.square} />
-                <ErrorAnalysisActivitiesSection styles={styles}/>
-                <RightOnGameShow />
-                <div className={styles.hexagon} />
+            <div className={styles.resourcesPageBk} style={{position: 'relative', zIndex: '-1'}}>
+                <ResourcePageShapes />
+                <div style={ {position: 'relative', zIndex: '1'} }>
+                    <PositiveCultureOfErrorSection styles={styles}/>
+                    <CRMT />
+                    <ErrorAnalysisActivitiesSection styles={styles}/>
+                    <RightOnGameShow />
+                </div>
             </div>
         )
     }


### PR DESCRIPTION
Added background shapes from the Figma file into the Resources page. Div styles are located in App.js and are separated by shape name (any way to make one container called 'shapes'?). Also, square div is overflowing and increasing the width of the page. `overflow: 'hidden'` worked for me before, but with the recent Resources page changes I'm not sure where to add this CSS.