### PR TITLE
Fixed text wrapping and edited background gradient

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,8 +88,18 @@ const useStyles = makeStyles( theme => ({
     lineHeight: "1.4",
     listStyle: "inside",
     [theme.breakpoints.down('xs')]: {
-      fontSize: '1em'
+      fontSize: '1em',
+      justifyContent: 'center',
     }
+  },
+  positiveCultureofErrorCardIntro: {
+    justifyContent: 'center',
+    color: 'white',
+    width: '85%',
+    position: "relative",
+    padding: "5%",
+    margin: 'auto',
+    mixBlendMode: 'initial',
   }
 }))
 

--- a/src/components/molecules/PositiveCultureBox.jsx
+++ b/src/components/molecules/PositiveCultureBox.jsx
@@ -5,13 +5,15 @@ import quote from '../../images/Resources_Quote.png'
 function PositiveCultureBox(props) {
     const { styles } = props
         return(
-          <Card className={styles.cardIntro} style={{background: 'linear-gradient(52.63deg, #FF3369 0%, #662AAF 73.19%)', mixBlendMode: 'initial'}}> {/*background: 'rgba(41, 0, 83, 0.8)'*/}
+          <Card className={styles.positiveCultureofErrorCardIntro} style={{background: 'linear-gradient(232.63deg, rgba(102, 42, 175, 0.93), rgba(255, 51, 105, 0.83))',}}> {/*background: 'rgba(41, 0, 83, 0.8)'; linear-gradient(52.63deg, #FF3369 0%, #662AAF 73.19%); */}
               <CardContent>
               <Grid container justify="center" alignItems="center" spacing={3}>
-                  <Grid item xs={6} md={5} lg={7} style={{padding: 'initial'}}>
+                  <Grid item xs={12} md={5} lg={7} style={{padding: 'initial'}}>
                     <Typography variant="h4">Positive Culture of Error</Typography>
                     <Typography variant="h6" className={styles.positiveCultureofErrorCardContent}>
                     In his book, <u>Teach Like a Champion</u>, veteran educator Doug Lemov talks about creating a classroom environment where “...students feel safe making and discussing mistakes, so you can spend less time hunting for errors and more time fixing them...” He outlines four key methods:
+                    </Typography>
+                    <Typography variant="h6" className={styles.positiveCultureofErrorCardContent}>
                       <ul>
                         <li>Expect error</li>
                         <li>Withhold answers</li>
@@ -20,8 +22,8 @@ function PositiveCultureBox(props) {
                       </ul> 
                     </Typography>
                   </Grid>
-                  <Hidden xsDown='true'>
-                  <Grid item xs={6} md={7} lg={5} style={{padding: 'initial'}}>
+                  <Hidden smDown='true'>
+                  <Grid item xs={12} md={7} lg={5} style={{padding: 'initial'}}>
                     <a target="amazon" href="https://www.amazon.com/Rough-Draft-Math-Revising-Learn/dp/1625312067/"><img src={quote} width="100%"></img></a>
                     {/* <Card className={styles.cardContent} style={{"background": "white"}}>
                         <Typography variant="h5">

--- a/src/components/organisms/ResourcePageShapes.jsx
+++ b/src/components/organisms/ResourcePageShapes.jsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 const circle = {
     position: 'absolute',
     top: '65vw',


### PR DESCRIPTION
- Changed sizing of grid boxes in 'xs' and 'sm' views to take advantage of full card size
- Changed hiding of image from 'xsDown' to 'smDown'
- Updated background gradient to add the transparency from the Figma design

Fixes #43 